### PR TITLE
chore: Increase fetch depth to 2 for Codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2 # required for Codecov to be able to identify the commit
       - run: |
           npm install
       - run: |


### PR DESCRIPTION
#6 

I had forgotten that Codecov requires a fetch depth of at least 2 to be able to identify the commit.